### PR TITLE
Fix how the version file update is added to git

### DIFF
--- a/bin/create_release
+++ b/bin/create_release
@@ -395,11 +395,17 @@ class ReleaseCreator
     print 'Updating version...'
     message, status = Bump::Bump.run(options.release_type, commit: false)
     error 'Could not bump version' unless status == 0
-    `git add lib/git/version.rb`
+    version_file = `bump file`.chomp
     if $CHILD_STATUS.success?
       puts 'OK'
     else
-      error 'Could not stage changes to lib/git/version.rb'
+      error 'Could not get version file'
+    end
+    `git add #{version_file}`
+    if $CHILD_STATUS.success?
+      puts 'OK'
+    else
+      error "Could not stage changes to the version file '#{version_file}'"
     end
   end
 


### PR DESCRIPTION
Don't hardcode the version file name when adding to git.